### PR TITLE
fix: Fix APNS custom keys assembling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0
+
+  * [FIX] APNS custom data properly incorporate into the push notification payload. So instead of passing ``custom_data``
+  as-is into payload and by that introducing one more nested level, extract all the key from ``custom_data`` and
+  put them on the same level as ``aps`` attribute.
+
 ## 1.2.1
 
   * Added verbosity when making request to Firebase

--- a/async_firebase/messages.py
+++ b/async_firebase/messages.py
@@ -129,7 +129,15 @@ class APNSPayload:
 
     Attributes:
     aps: a ``messages.Aps`` instance to be included in the payload.
-    custom_data: arbitrary keyword arguments to be included as custom fields in the payload (optional).
+    custom_data: arbitrary keyword arguments to be included as custom fields in the payload (optional). This attribute
+        will be then re-assembled according to the format allowed by APNS. Below you may find details:
+
+        In addition to the Apple-defined keys, custom keys may be added to payload to deliver small amounts of data
+        to app, notification service app extension, or notification content app extension. Custom keys must
+        have values with primitive types, such as dictionary, array, string, number, or Boolean. Custom keys are
+        available in the ``userInfo`` dictionary of the ``UNNotificationContent`` object delivered to app.
+
+        In a nutshell custom keys should be incorporated on the same level as ``apns`` attribute.
     """
 
     aps: t.Optional[Aps] = field(default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-firebase"
-version = "1.2.1"
+version = "1.3.0"
 description = "Async Firebase Client - a Python asyncio client to interact with Firebase Cloud Messaging in an easy way."
 license = "MIT"
 authors = [


### PR DESCRIPTION
Extract customer keys from the dictionary ``custom_data`` and
incorporate them on the same level as ``aps`` attribute.