### PR TITLE
fix: Change APNSPayload message structure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+
+  * [FIX] ``APNSPayload`` message no longer support attribute ``custom_data``
+
 ## 1.3.0
 
   * [FIX] APNS custom data properly incorporate into the push notification payload. So instead of passing ``custom_data``

--- a/async_firebase/client.py
+++ b/async_firebase/client.py
@@ -365,8 +365,8 @@ class AsyncFirebaseClient:
         apns_custom_data: t.Dict[str, t.Any] = {}
         has_apns_config = True if apns and apns.payload else False
         if has_apns_config:
-            apns_custom_data = deepcopy(apns.payload.custom_data)  # type: ignore
-            apns.payload.custom_data.clear()  # type: ignore
+            apns_custom_data = deepcopy(apns.payload.aps.custom_data)  # type: ignore
+            apns.payload.aps.custom_data.clear()  # type: ignore
 
         push_notification: t.Dict[str, t.Any] = cleanup_firebase_message(
             PushNotification(message=message, validate_only=dry_run)

--- a/async_firebase/messages.py
+++ b/async_firebase/messages.py
@@ -109,7 +109,15 @@ class Aps:
     thread_id: an app-specific string identifier for grouping messages (optional).
     mutable_content: a boolean indicating whether to support mutating notifications at the client using app extensions
         (optional).
-    custom_data: a dictionary of custom key-value pairs to be included in the Aps dictionary (optional).
+    custom_data: a dictionary of custom key-value pairs to be included in the Aps dictionary (optional). These
+        attributes will be then re-assembled according to the format allowed by APNS. Below you may find details:
+
+        In addition to the Apple-defined keys, custom keys may be added to payload to deliver small amounts of data
+        to app, notification service app extension, or notification content app extension. Custom keys must
+        have values with primitive types, such as dictionary, array, string, number, or Boolean. Custom keys are
+        available in the ``userInfo`` dictionary of the ``UNNotificationContent`` object delivered to app.
+
+        In a nutshell custom keys should be incorporated on the same level as ``apns`` attribute.
     """
 
     alert: t.Union[str, ApsAlert, None] = None
@@ -129,19 +137,9 @@ class APNSPayload:
 
     Attributes:
     aps: a ``messages.Aps`` instance to be included in the payload.
-    custom_data: arbitrary keyword arguments to be included as custom fields in the payload (optional). This attribute
-        will be then re-assembled according to the format allowed by APNS. Below you may find details:
-
-        In addition to the Apple-defined keys, custom keys may be added to payload to deliver small amounts of data
-        to app, notification service app extension, or notification content app extension. Custom keys must
-        have values with primitive types, such as dictionary, array, string, number, or Boolean. Custom keys are
-        available in the ``userInfo`` dictionary of the ``UNNotificationContent`` object delivered to app.
-
-        In a nutshell custom keys should be incorporated on the same level as ``apns`` attribute.
     """
 
     aps: t.Optional[Aps] = field(default=None)
-    custom_data: t.Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-firebase"
-version = "1.3.0"
+version = "1.3.1"
 description = "Async Firebase Client - a Python asyncio client to interact with Firebase Cloud Messaging in an easy way."
 license = "MIT"
 authors = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -162,7 +162,8 @@ async def test_make_async_pre_created_thread_pool_executor():
             Aps(alert="alert", badge=9), {"alert": "alert", "badge": 9}
         ),
         (
-            APNSPayload(custom_data={"foo": "bar"}), {"custom_data": {"foo": "bar"}}
+            APNSPayload(aps=Aps(alert="push-text", custom_data={"foo": "bar"})),
+            {"aps": {"alert": "push-text", "custom_data": {"foo": "bar"}}}
         ),
         (
             APNSConfig(headers={"x-header": "x-data"}), {"headers": {"x-header": "x-data"}}


### PR DESCRIPTION
The ``APNSPayload`` no longer supports attribute custom_data.