### PR TITLE
feat: add channel_id to android notification params

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0
+
+  * Added channel_id option to Android config ([spec](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#AndroidNotification))
+
 ## 1.3.5
 
   * [FIX] Adjust APS encoder in order to properly construct background push notification.

--- a/async_firebase/client.py
+++ b/async_firebase/client.py
@@ -125,6 +125,7 @@ class AsyncFirebaseClient:
         body_loc_args: t.List[str] = None,
         title_loc_key: str = None,
         title_loc_args: t.List[str] = None,
+        channel_id: t.Optional[str] = None,
     ) -> AndroidConfig:
         """
         Constructs AndroidConfig that will be used to customize the messages that are sent to Android device.
@@ -155,6 +156,8 @@ class AsyncFirebaseClient:
             title text (optional).
         :param title_loc_args: A list of resource keys that will be used in place of the format specifiers
             in ``title_loc_key`` (optional).
+        :param channel_id: Notification channel id, used by android to allow user to configure notification display
+            rules on per-channel basis (optional).
         :return: an instance of ``messages.AndroidConfig`` to be included in the resulting payload.
         """
         if data:
@@ -178,6 +181,7 @@ class AsyncFirebaseClient:
                 body_loc_args=body_loc_args or [],
                 title_loc_key=title_loc_key,
                 title_loc_args=title_loc_args or [],
+                channel_id=channel_id,
             ),
         )
 

--- a/async_firebase/messages.py
+++ b/async_firebase/messages.py
@@ -41,6 +41,7 @@ class AndroidNotification:
     body_loc_args: t.List[str] = field(default_factory=list)
     title_loc_key: t.Optional[str] = None
     title_loc_args: t.List[str] = field(default_factory=list)
+    channel_id: t.Optional[str] = None
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-firebase"
-version = "1.3.5"
+version = "1.4.0"
 description = "Async Firebase Client - a Python asyncio client to interact with Firebase Cloud Messaging in an easy way."
 license = "MIT"
 authors = [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -78,7 +78,8 @@ def test_build_android_config(fake_async_fcm_client_w_creds):
         color="red",
         sound="beep",
         tag="test",
-        click_action="TOP_STORY_ACTIVITY"
+        click_action="TOP_STORY_ACTIVITY",
+        channel_id="some_channel_id",
     )
     assert android_config == AndroidConfig(**{
         "priority": "high",
@@ -97,7 +98,8 @@ def test_build_android_config(fake_async_fcm_client_w_creds):
             "body_loc_key": None,
             "body_loc_args": [],
             "title_loc_key": None,
-            "title_loc_args": []
+            "title_loc_args": [],
+            "channel_id": "some_channel_id",
         })
     })
 


### PR DESCRIPTION
In accordance with firebase cloud messaging spec:
https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#AndroidNotification