### PR TITLE
feat: add notification_count field to AndroidNotification

### DIFF
--- a/async_firebase/client.py
+++ b/async_firebase/client.py
@@ -176,6 +176,7 @@ class AsyncFirebaseClient:
         title_loc_key: t.Optional[str] = None,
         title_loc_args: t.Optional[t.List[str]] = None,
         channel_id: t.Optional[str] = None,
+        notification_count: t.Optional[int] = None,
     ) -> AndroidConfig:
         """
         Constructs AndroidConfig that will be used to customize the messages that are sent to Android device.
@@ -208,6 +209,9 @@ class AsyncFirebaseClient:
             in ``title_loc_key`` (optional).
         :param channel_id: Notification channel id, used by android to allow user to configure notification display
             rules on per-channel basis (optional).
+        :param notification_count: The number of items in notification. May be displayed as a badge count for launchers
+            that support badging. If zero or unspecified, systems that support badging use the default, which is to
+            increment a number displayed on the long-press menu each time a new notification arrives (optional).
         :return: an instance of ``messages.AndroidConfig`` to be included in the resulting payload.
         """
         android_config = AndroidConfig(
@@ -229,6 +233,7 @@ class AsyncFirebaseClient:
                 title_loc_key=title_loc_key,
                 title_loc_args=title_loc_args or [],
                 channel_id=channel_id,
+                notification_count=notification_count,
             ),
         )
 

--- a/async_firebase/messages.py
+++ b/async_firebase/messages.py
@@ -30,6 +30,13 @@ class AndroidNotification:
     title_loc_key: key of the title string in the app's string resources to use to localize the title text (optional).
     title_loc_args: a list of resource keys that will be used in place of the format specifiers in ``title_loc_key``
         (optional).
+    channel_id: The notification's channel id (new in Android O). The app must create a channel with this channel ID
+        before any notification with this channel ID is received. If you don't send this channel ID in the request,
+        or if the channel ID provided has not yet been created by the app, FCM uses the channel ID specified in the
+        app manifest.
+    notification_count: the number of items this notification represents (optional). If zero or unspecified, systems
+        that support badging use the default, which is to increment a number displayed on the long-press menu each time
+        a new notification arrives.
     """
 
     title: t.Optional[str] = None
@@ -44,6 +51,7 @@ class AndroidNotification:
     title_loc_key: t.Optional[str] = None
     title_loc_args: t.List[str] = field(default_factory=list)
     channel_id: t.Optional[str] = None
+    notification_count: t.Optional[int] = None
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -63,6 +63,7 @@ def test_build_android_config(fake_async_fcm_client_w_creds):
         tag="test",
         click_action="TOP_STORY_ACTIVITY",
         channel_id="some_channel_id",
+        notification_count=7,
     )
     assert android_config == AndroidConfig(
         **{
@@ -85,6 +86,7 @@ def test_build_android_config(fake_async_fcm_client_w_creds):
                     "title_loc_key": None,
                     "title_loc_args": [],
                     "channel_id": "some_channel_id",
+                    "notification_count": 7,
                 }
             ),
         }


### PR DESCRIPTION
Hi, thanks for this library.

This PR adds `notification_count` field to `android.notification` object according to documentation 
https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidnotification

I want to merge it to the upstream since we need this field in our production code and I don't want to maintain my own fork of your library :)

feel free to add any comments, here is tests results
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/6561391/213140874-d4d09f04-d94d-4ffc-87a6-3c593e401723.png">




