### PR TITLE
Change the type hint of webpush

### DIFF
--- a/async_firebase/client.py
+++ b/async_firebase/client.py
@@ -388,7 +388,7 @@ class AsyncFirebaseClient:
         data: t.Optional[t.Dict[str, str]] = None,
         notification: t.Optional[Notification] = None,
         topic: t.Optional[str] = None,
-        webpush: t.Optional[t.Dict[str, str]] = None,
+        webpush: t.Optional[t.Dict[str, t.Any]] = None,
         dry_run: bool = False,
     ) -> FcmPushResponse:
         """
@@ -474,7 +474,7 @@ class AsyncFirebaseClient:
         apns: t.Optional[APNSConfig] = None,
         data: t.Optional[t.Dict[str, str]] = None,
         notification: t.Optional[Notification] = None,
-        webpush: t.Optional[t.Dict[str, str]] = None,
+        webpush: t.Optional[t.Dict[str, t.Any]] = None,
         dry_run: bool = False,
     ) -> FcmPushMulticastResponse:
         """


### PR DESCRIPTION
Change the type hint of `push` and `push_multicast`'s `webpush` into `dict[str, Any]` so that we can create and use direct dict before implementing WebpushConfig.

[WebpushConfig Reference](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#webpushconfig)