### PR TITLE
Remove reference clear for parent dict

### DIFF
--- a/async_firebase/encoders.py
+++ b/async_firebase/encoders.py
@@ -18,7 +18,6 @@ def aps_encoder(aps: Aps) -> t.Optional[t.Dict[str, t.Any]]:
         return None
 
     custom_data: t.Dict[str, t.Any] = deepcopy(aps.custom_data) or {}  # type: ignore
-    aps.custom_data.clear()  # type: ignore
 
     payload = {
         "aps": {

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -102,3 +102,28 @@ from async_firebase.messages import Aps, ApsAlert
 def test_aps_encoder(aps_obj, exp_result):
     aps_dict = aps_encoder(aps_obj)
     assert aps_dict == exp_result
+
+def test_aps_encoder_does_not_modify_custom_data():
+    custom_data = {
+        "str_attr": "value_1",
+        "int_attr": 42,
+        "float_attr": 42.42,
+        "list_attr": [1, 2, 3],
+        "dict_attr": {"a": "A", "b": "B"},
+        "bool_attr": False,
+    }
+
+    aps = Aps(
+        alert="push text",
+        badge=5,
+        sound="default",
+        content_available=True,
+        category="NEW_MESSAGE",
+        mutable_content=False,
+        custom_data=custom_data.copy(),
+    )
+
+    assert aps.custom_data == custom_data
+    aps_encoder(aps)
+    assert len(custom_data) == 6
+    assert aps.custom_data == custom_data


### PR DESCRIPTION
**Describe the bug**
On iOS only the first message with `custom_data` get's the actual data, any subsequent notifications don't get any content in `custom_data`.


**To Reproduce**
Steps to reproduce the behavior:
This can be observed anytime a single apns object is used.

example 1:
```py
ios = [ .... device tokens, ]

apns = client.build_apns_config(
  content_available=True,
  priority="5",
  custom_data={ 'hello': 'world' }
)
print(apns.payload.aps.custom_data) # => { 'hello': 'world' }
await client.push_multicast(ios, apns=apns)

print(apns.payload.aps.custom_data) # => {}
```

example 2:
```py
apns = client.build_apns_config(
  content_available=True,
  priority="5",
  custom_data={ 'hello': 'world' }
)

print(apns.payload.aps.custom_data) # => { 'hello': 'world' }
for device in ios:
  #  if first iteration
  print(apns.payload.aps.custom_data) # => { 'hello': 'world' }
  # second iteration
  print(apns.payload.aps.custom_data) # => {}

  await client.push(device, apns=apns)
  # always
  print(apns.payload.aps.custom_data) # => {}
```

**Expected behavior**
All devices receive the same data.


**Additional context**
If line 21 in `encoder.py` is removed, it works.
```py
aps.custom_data.clear()  # type: ignore
```


All tests are still running.