### PR TITLE
feat: Remastering client to support sending multiple messages in a single batch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,11 @@
 
 ## 3.0.0
 Remastering client interface
-* [BREAKING] The signatures of the methods ``push`` and ``push_multicast`` have been changed.
+* [BREAKING] The methods ``push`` and ``push_multicast`` renamed to ``send`` and ``send_multicast`` accordingly.
+* [BREAKING] The signatures of the methods ``send`` and ``send_multicast`` have been changed.
   * Method ``push`` accepts instance of ``messages.Message`` and returns ``messages.FcmPushBatchResponse``
   * Method ``push_multicast`` accepts instance of ``messages.MulticastMessage`` and returns ``messages.FcmPushBatchResponse``
-* New method ``push_batch`` to send message in a single batch has been added. It takes a list of ``messages.Message`` instances.
+* New method ``send_all`` to send messages in a single batch has been added. It takes a list of ``messages.Message`` instances.
 * ``README.md`` has been updated to highlight different in interfaces for versions prior **3.x** and after
 * Error class ``FcmPushMulticastResponse`` renamed to ``FcmPushBatchResponse``.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 3.0.0
+Remastering client interface
+* [BREAKING] The signatures of the methods ``push`` and ``push_multicast`` have been changed.
+  * Method ``push`` accepts instance of ``messages.Message`` and returns ``messages.FcmPushBatchResponse``
+  * Method ``push_multicast`` accepts instance of ``messages.MulticastMessage`` and returns ``messages.FcmPushBatchResponse``
+* New method ``push_batch`` to send message in a single batch has been added. It takes a list of ``messages.Message`` instances.
+* To get closer to official library ``firebase-admin`` a couple of handy aliases have been added:
+  * ``send => push``
+  * ``send_all | send_batch => push_batch``
+  * ``send_multicast => push_multicast``
+
+  Example:
+    * ``client.send(Message(...))``
+    * ``client.send_multicast(MulticastMessage(...))``
+    * ``client.send_all([Message(...), Message(...)])``
+
+* ``README.md`` has been updated to highlight different in interfaces for versions prior **3.x** and after
+* Error class ``FcmPushMulticastResponse`` renamed to ``FcmPushBatchResponse``.
+
 ## 2.7.0
 * Class ``AsyncFirebaseClient`` has been refactored. Communication related code extracted into base class.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,16 +6,6 @@ Remastering client interface
   * Method ``push`` accepts instance of ``messages.Message`` and returns ``messages.FcmPushBatchResponse``
   * Method ``push_multicast`` accepts instance of ``messages.MulticastMessage`` and returns ``messages.FcmPushBatchResponse``
 * New method ``push_batch`` to send message in a single batch has been added. It takes a list of ``messages.Message`` instances.
-* To get closer to official library ``firebase-admin`` a couple of handy aliases have been added:
-  * ``send => push``
-  * ``send_all | send_batch => push_batch``
-  * ``send_multicast => push_multicast``
-
-  Example:
-    * ``client.send(Message(...))``
-    * ``client.send_multicast(MulticastMessage(...))``
-    * ``client.send_all([Message(...), Message(...)])``
-
 * ``README.md`` has been updated to highlight different in interfaces for versions prior **3.x** and after
 * Error class ``FcmPushMulticastResponse`` renamed to ``FcmPushBatchResponse``.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ pip install async-firebase
 ```
 
 ## Getting started
+### async-firebase < 3.0.0
 To send push notification to Android:
 ```python3
 import asyncio
@@ -140,6 +141,131 @@ async def main():
     client = AsyncFirebaseClient()
     client.creds_from_service_account_info({...})
     response = await client.push(device_token=device_token, apns=apns_config)
+    print(response.success)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### async-firebase >= 3.0.0
+To send push notification to Android:
+```python3
+import asyncio
+
+from async_firebase import AsyncFirebaseClient
+from async_firebase.messages import Message
+
+
+async def main():
+    client = AsyncFirebaseClient()
+    client.creds_from_service_account_file("secret-store/mobile-app-79225efac4bb.json")
+
+    # or using dictionary object
+    # client.creds_from_service_account_info({...}})
+
+    device_token: str = "..."
+
+    android_config = client.build_android_config(
+        priority="high",
+        ttl=2419200,
+        collapse_key="push",
+        data={"discount": "15%", "key_1": "value_1", "timestamp": "2021-02-24T12:00:15"},
+        title="Store Changes",
+        body="Recent store changes",
+    )
+    message = Message(android=android_config, token=device_token)
+    response = await client.push(message)
+
+    print(response.success, response.message_id)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+To send push notification to iOS:
+
+```python3
+import asyncio
+
+from async_firebase import AsyncFirebaseClient
+from async_firebase.messages import Message
+
+
+async def main():
+    client = AsyncFirebaseClient()
+    client.creds_from_service_account_file("secret-store/mobile-app-79225efac4bb.json")
+
+    # or using dictionary object
+    # client.creds_from_service_account_info({...}})
+
+    device_token: str = "..."
+
+    apns_config = client.build_apns_config(
+        priority="normal",
+        ttl=2419200,
+        apns_topic="store-updated",
+        collapse_key="push",
+        title="Store Changes",
+        alert="Recent store changes",
+        badge=1,
+        category="test-category",
+        custom_data={"discount": "15%", "key_1": "value_1", "timestamp": "2021-02-24T12:00:15"}
+    )
+    message = Message(apns=apns_config, token=device_token)
+    response = await client.push(message)
+
+    print(response.success)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+This prints:
+
+```shell script
+"projects/mobile-app/messages/0:2367799010922733%7606eb557606ebff"
+```
+
+To manual construct message:
+```python3
+import asyncio
+from datetime import datetime
+
+from async_firebase.messages import APNSConfig, APNSPayload, ApsAlert, Aps, Message
+from async_firebase import AsyncFirebaseClient
+
+
+async def main():
+    apns_config = APNSConfig(**{
+        "headers": {
+            "apns-expiration": str(int(datetime.utcnow().timestamp()) + 7200),
+            "apns-priority": "10",
+            "apns-topic": "test-topic",
+            "apns-collapse-id": "something",
+        },
+        "payload": APNSPayload(**{
+            "aps": Aps(**{
+                "alert": ApsAlert(title="some-title", body="alert-message"),
+                "badge": 0,
+                "sound": "default",
+                "content_available": True,
+                "category": "some-category",
+                "mutable_content": False,
+                "custom_data": {
+                    "link": "https://link-to-somewhere.com",
+                    "ticket_id": "YXZ-655512",
+                },
+            })
+        })
+    })
+
+    device_token: str = "..."
+
+    client = AsyncFirebaseClient()
+    client.creds_from_service_account_info({...})
+    message = Message(apns=apns_config, token=device_token)
+    response = await client.push(message)
     print(response.success)
 
 

--- a/async_firebase/base.py
+++ b/async_firebase/base.py
@@ -16,7 +16,7 @@ import httpx
 from google.oauth2 import service_account  # type: ignore
 
 import pkg_resources  # type: ignore
-from async_firebase.messages import FcmPushMulticastResponse, FcmPushResponse
+from async_firebase.messages import FcmPushBatchResponse, FcmPushResponse
 from async_firebase.utils import (
     FcmPushMulticastResponseHandler,
     FcmPushResponseHandler,
@@ -155,7 +155,7 @@ class AsyncClientBase:
         json_payload: t.Optional[t.Dict[str, t.Any]] = None,
         headers: t.Optional[t.Dict[str, str]] = None,
         content: t.Union[str, bytes, t.Iterable[bytes], t.AsyncIterable[bytes], None] = None,
-    ) -> t.Union[FcmPushResponse, FcmPushMulticastResponse]:
+    ) -> t.Union[FcmPushResponse, FcmPushBatchResponse]:
         """
         Sends an HTTP call using the ``httpx`` library.
 

--- a/async_firebase/client.py
+++ b/async_firebase/client.py
@@ -24,10 +24,10 @@ from async_firebase.messages import (
     APNSPayload,
     Aps,
     ApsAlert,
-    FcmPushMulticastResponse,
+    FcmPushBatchResponse,
     FcmPushResponse,
     Message,
-    Notification,
+    MulticastMessage,
     PushNotification,
     WebpushConfig,
     WebpushFCMOptions,
@@ -332,31 +332,11 @@ class AsyncFirebaseClient(AsyncClientBase):
             fcm_options=WebpushFCMOptions(link=link) if link else None,
         )
 
-    async def push(  # pylint: disable=too-many-locals
-        self,
-        device_token: str,
-        *,
-        android: t.Optional[AndroidConfig] = None,
-        apns: t.Optional[APNSConfig] = None,
-        condition: t.Optional[str] = None,
-        data: t.Optional[t.Dict[str, str]] = None,
-        notification: t.Optional[Notification] = None,
-        topic: t.Optional[str] = None,
-        webpush: t.Optional[WebpushConfig] = None,
-        dry_run: bool = False,
-    ) -> FcmPushResponse:
+    async def push(self, message: Message, *, dry_run: bool = False) -> FcmPushResponse:
         """
         Send push notification.
 
-        :param device_token: device token allows to send targeted notifications to a particular instance of app.
-        :param android: as instance of ``messages.AndroidConfig`` that contains Android-specific options.
-        :param apns: as instance of ``messages.APNSConfig`` that contains iOS-specific options.
-        :param condition: the Firebase condition to which the message should be sent.
-        :param data: a dictionary of data fields. All keys and values in the dictionary must be strings.
-        :param notification: an instance of ``messages.Notification`` that contains a notification that can be included
-            in a resulting message.
-        :param topic: name of the Firebase topic to which the message should be sent.
-        :param webpush: an instance of ``messages.WebpushConfig``.
+        :param message: the message that has to be sent.
         :param dry_run: indicating whether to run the operation in dry run mode (optional). Flag for testing the request
             without actually delivering the message. Default to ``False``.
 
@@ -397,18 +377,7 @@ class AsyncFirebaseClient(AsyncClientBase):
                     }
                 }
         """
-        message = Message(
-            token=device_token,
-            data=data or {},
-            notification=notification,
-            android=android,
-            webpush=webpush,
-            apns=apns,
-            topic=topic,
-            condition=condition,
-        )
-
-        push_notification = self.assemble_push_notification(apns_config=apns, dry_run=dry_run, message=message)
+        push_notification = self.assemble_push_notification(apns_config=message.apns, dry_run=dry_run, message=message)
 
         response = await self.send_request(
             uri=self.FCM_ENDPOINT.format(project_id=self._credentials.project_id),  # type: ignore
@@ -421,55 +390,65 @@ class AsyncFirebaseClient(AsyncClientBase):
 
     async def push_multicast(
         self,
-        device_tokens: t.Union[t.List[str], t.Tuple[str]],
+        multicast_message: MulticastMessage,
         *,
-        android: t.Optional[AndroidConfig] = None,
-        apns: t.Optional[APNSConfig] = None,
-        data: t.Optional[t.Dict[str, str]] = None,
-        notification: t.Optional[Notification] = None,
-        webpush: t.Optional[WebpushConfig] = None,
         dry_run: bool = False,
-    ) -> FcmPushMulticastResponse:
+    ) -> FcmPushBatchResponse:
         """
         Send Multicast push notification.
 
-        :param device_tokens: the list of device tokens to send targeted notifications to a set of instances of app.
+        :param multicast_message: multicast message to send targeted notifications to a set of instances of app.
             May contain up to 500 device tokens.
-        :param android: as instance of ``messages.AndroidConfig`` that contains Android-specific options.
-        :param apns: as instance of ``messages.APNSConfig`` that contains iOS-specific options.
-        :param data: a dictionary of data fields. All keys and values in the dictionary must be strings.
-        :param notification: an instance of ``messages.Notification`` that contains a notification that can be included
-            in a resulting message.
-        :param webpush: an instance of ``messages.WebpushConfig``.
         :param dry_run: indicating whether to run the operation in dry run mode (optional). Flag for testing the request
             without actually delivering the message. Default to ``False``.
         """
 
-        if len(device_tokens) > MULTICAST_MESSAGE_MAX_DEVICE_TOKENS:
+        if len(multicast_message.tokens) > MULTICAST_MESSAGE_MAX_DEVICE_TOKENS:
             raise ValueError(
                 f"A single ``messages.MulticastMessage`` may contain up to {MULTICAST_MESSAGE_MAX_DEVICE_TOKENS} "
                 "device tokens."
             )
 
+        messages = [
+            Message(
+                token=token,
+                data=multicast_message.data,
+                notification=multicast_message.notification,
+                android=multicast_message.android,
+                webpush=multicast_message.webpush,
+                apns=multicast_message.apns,
+            )
+            for token in multicast_message.tokens
+        ]
+
+        return await self.push_batch(messages, dry_run=dry_run)
+
+    async def push_batch(
+        self,
+        messages: t.Union[t.List[Message], t.Tuple[Message]],
+        *,
+        dry_run: bool = False,
+    ) -> FcmPushBatchResponse:
+        """
+        Send push notifications as a single batch.
+
+        :param messages: the list of messages to send.
+        :param dry_run: indicating whether to run the operation in dry run mode (optional). Flag for testing the request
+            without actually delivering the message. Default to ``False``.
+        """
+
         multipart_message = MIMEMultipart("mixed")
         # Message should not write out it's own headers.
         setattr(multipart_message, "_write_headers", lambda self: None)
 
-        for device_token in device_tokens:
+        for message in messages:
             msg = MIMENonMultipart("application", "http")
             msg["Content-Transfer-Encoding"] = "binary"
             msg["Content-ID"] = self.get_request_id()
             push_notification = self.assemble_push_notification(
-                apns_config=apns,
+                apns_config=message.apns,
                 dry_run=dry_run,
-                message=Message(
-                    token=device_token,
-                    data=data or {},
-                    notification=notification,
-                    android=android,
-                    webpush=webpush,
-                    apns=apns,
-                ),
+                message=message,
             )
             body = self.serialize_batch_request(
                 httpx.Request(
@@ -493,6 +472,11 @@ class AsyncFirebaseClient(AsyncClientBase):
             headers={"Content-Type": f"multipart/mixed; boundary={multipart_message.get_boundary()}"},
             response_handler=FcmPushMulticastResponseHandler(),
         )
-        if not isinstance(batch_response, FcmPushMulticastResponse):
+        if not isinstance(batch_response, FcmPushBatchResponse):
             raise ValueError("Wrong return type, perhaps because of a response handler misuse.")
         return batch_response
+
+    # Handy aliases to get closer to firebase-admin naming
+    send = push
+    send_multicast = push_multicast
+    send_all = send_batch = push_batch

--- a/async_firebase/client.py
+++ b/async_firebase/client.py
@@ -332,7 +332,7 @@ class AsyncFirebaseClient(AsyncClientBase):
             fcm_options=WebpushFCMOptions(link=link) if link else None,
         )
 
-    async def push(self, message: Message, *, dry_run: bool = False) -> FcmPushResponse:
+    async def send(self, message: Message, *, dry_run: bool = False) -> FcmPushResponse:
         """
         Send push notification.
 
@@ -388,7 +388,7 @@ class AsyncFirebaseClient(AsyncClientBase):
             raise ValueError("Wrong return type, perhaps because of a response handler misuse.")
         return response
 
-    async def push_multicast(
+    async def send_multicast(
         self,
         multicast_message: MulticastMessage,
         *,
@@ -421,16 +421,16 @@ class AsyncFirebaseClient(AsyncClientBase):
             for token in multicast_message.tokens
         ]
 
-        return await self.push_batch(messages, dry_run=dry_run)
+        return await self.send_all(messages, dry_run=dry_run)
 
-    async def push_batch(
+    async def send_all(
         self,
         messages: t.Union[t.List[Message], t.Tuple[Message]],
         *,
         dry_run: bool = False,
     ) -> FcmPushBatchResponse:
         """
-        Send push notifications as a single batch.
+        Send push notifications in a single batch.
 
         :param messages: the list of messages to send.
         :param dry_run: indicating whether to run the operation in dry run mode (optional). Flag for testing the request

--- a/async_firebase/client.py
+++ b/async_firebase/client.py
@@ -475,8 +475,3 @@ class AsyncFirebaseClient(AsyncClientBase):
         if not isinstance(batch_response, FcmPushBatchResponse):
             raise ValueError("Wrong return type, perhaps because of a response handler misuse.")
         return batch_response
-
-    # Handy aliases to get closer to firebase-admin naming
-    send = push
-    send_multicast = push_multicast
-    send_all = send_batch = push_batch

--- a/async_firebase/messages.py
+++ b/async_firebase/messages.py
@@ -299,7 +299,7 @@ class Message:
     condition: the Firebase condition to which the message should be sent (optional).
     """
 
-    token: t.Optional[str]
+    token: str
     data: t.Dict[str, str] = field(default_factory=dict)
     notification: t.Optional[Notification] = field(default=None)
     android: t.Optional[AndroidConfig] = field(default=None)
@@ -307,6 +307,28 @@ class Message:
     apns: t.Optional[APNSConfig] = field(default=None)
     topic: t.Optional[str] = None
     condition: t.Optional[str] = None
+
+
+@dataclass
+class MulticastMessage:
+    """
+    A message that can be sent to multiple tokens via Firebase.
+
+    Attributes:
+    tokens: a list of registration tokens of targeted devices.
+    data: a dictionary of data fields (optional). All keys and values in the dictionary must be strings.
+    notification: an instance of ``messages.Notification`` (optional).
+    android: an instance of ``messages.AndroidConfig`` (optional).
+    webpush: an instance of ``messages.WebpushConfig`` (optional).
+    apns: an instance of ``messages.ApnsConfig`` (optional).
+    """
+
+    tokens: t.List[str]
+    data: t.Dict[str, str] = field(default_factory=dict)
+    notification: t.Optional[Notification] = field(default=None)
+    android: t.Optional[AndroidConfig] = field(default=None)
+    webpush: t.Optional[WebpushConfig] = field(default=None)
+    apns: t.Optional[APNSConfig] = field(default=None)
 
 
 @dataclass
@@ -346,7 +368,7 @@ class FcmPushResponse:
         return self.message_id is not None and not self.exception
 
 
-class FcmPushMulticastResponse:
+class FcmPushBatchResponse:
     """The response received from a batch request to the FCM API.
 
     The interface of this object is compatible with BatchResponse object of

--- a/async_firebase/utils.py
+++ b/async_firebase/utils.py
@@ -23,7 +23,7 @@ from async_firebase.errors import (
     UnknownError,
     UnregisteredError,
 )
-from async_firebase.messages import FcmPushMulticastResponse, FcmPushResponse
+from async_firebase.messages import FcmPushBatchResponse, FcmPushResponse
 
 
 def remove_null_values(dict_value: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
@@ -122,7 +122,7 @@ def serialize_mime_message(
     return fp.getvalue()
 
 
-FcmResponseType = t.TypeVar("FcmResponseType", FcmPushResponse, FcmPushMulticastResponse)
+FcmResponseType = t.TypeVar("FcmResponseType", FcmPushResponse, FcmPushBatchResponse)
 
 
 class FcmResponseHandler(ABC, t.Generic[FcmResponseType]):
@@ -260,10 +260,10 @@ class FcmPushResponseHandler(FcmResponseHandler[FcmPushResponse]):
         return self._handle_response(response)
 
 
-class FcmPushMulticastResponseHandler(FcmResponseHandler[FcmPushMulticastResponse]):
+class FcmPushMulticastResponseHandler(FcmResponseHandler[FcmPushBatchResponse]):
     def handle_error(self, error: httpx.HTTPError):
         fcm_response = self._handle_error(error)
-        return FcmPushMulticastResponse(responses=[fcm_response])
+        return FcmPushBatchResponse(responses=[fcm_response])
 
     def handle_response(self, response: httpx.Response):
         fcm_push_responses = []
@@ -275,7 +275,7 @@ class FcmPushMulticastResponseHandler(FcmResponseHandler[FcmPushMulticastRespons
             else:
                 fcm_push_responses.append(self._handle_response(single_resp))
 
-        return FcmPushMulticastResponse(responses=fcm_push_responses)
+        return FcmPushBatchResponse(responses=fcm_push_responses)
 
     @staticmethod
     def _deserialize_batch_response(response: httpx.Response) -> t.List[httpx.Response]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [tool.poetry]
 name = "async-firebase"
-version = "2.7.0"
+version = "3.0.0"
 description = "Async Firebase Client - a Python asyncio client to interact with Firebase Cloud Messaging in an easy way."
 license = "MIT"
 authors = [
-    "Aleksandr Omyshev <oomyshev@healthjoy.com>"
+    "Oleksandr Omyshev <oomyshev@healthjoy.com>"
 ]
 maintainers = [
     "Healthjoy Developers <developers@healthjoy.com>",
-    "Aleksandr Omyshev <oomyshev@healthjoy.com>"
+    "Oleksandr Omyshev <oomyshev@healthjoy.com>"
 ]
 readme = "README.md"
 repository = "https://github.com/healthjoy/async-firebase"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -163,7 +163,7 @@ async def test_push(fake_async_fcm_client_w_creds, fake_device_token, httpx_mock
         custom_data={"foo": "bar"},
     )
     message = Message(apns=apns_config, token=fake_device_token)
-    response = await fake_async_fcm_client_w_creds.push(message)
+    response = await fake_async_fcm_client_w_creds.send(message)
     assert isinstance(response, FcmPushResponse)
     assert response.success
     assert response.message_id == "projects/fake-mobile-app/messages/0:1612788010922733%7606eb247606eb24"
@@ -185,7 +185,7 @@ async def test_push_dry_run(fake_async_fcm_client_w_creds, fake_device_token, ht
         custom_data={"foo": "bar"},
     )
     message = Message(apns=apns_config, token=fake_device_token)
-    response = await fake_async_fcm_client_w_creds.push(message, dry_run=True)
+    response = await fake_async_fcm_client_w_creds.send(message, dry_run=True)
     assert isinstance(response, FcmPushResponse)
     assert response.success
     assert response.message_id == "projects/fake-mobile-app/messages/fake_message_id"
@@ -215,7 +215,7 @@ async def test_push_unauthenticated(fake_async_fcm_client_w_creds, httpx_mock: H
         custom_data={"foo": "bar"},
     )
     message = Message(apns=apns_config, token="qwerty:ytrewq")
-    fcm_response = await fake_async_fcm_client_w_creds.push(message)
+    fcm_response = await fake_async_fcm_client_w_creds.send(message)
 
     assert isinstance(fcm_response, FcmPushResponse)
     assert not fcm_response.success
@@ -227,7 +227,7 @@ async def test_push_unauthenticated(fake_async_fcm_client_w_creds, httpx_mock: H
 async def test_push_data_has_not_provided(fake_async_fcm_client_w_creds):
     message = Message(token="device_id:device_token")
     with pytest.raises(ValueError):
-        await fake_async_fcm_client_w_creds.push(message)
+        await fake_async_fcm_client_w_creds.send(message)
 
 
 def test_creds_from_service_account_info(fake_async_fcm_client, fake_service_account):
@@ -263,7 +263,7 @@ async def test_push_realistic_payload(fake_async_fcm_client_w_creds, fake_device
         content_available=True,
     )
     message = Message(apns=apns_config, token=fake_device_token)
-    await fake_async_fcm_client_w_creds.push(message)
+    await fake_async_fcm_client_w_creds.send(message)
     request_payload = json.loads(httpx_mock.get_requests()[0].read())
     assert request_payload == {
         "message": {
@@ -324,7 +324,7 @@ async def test_push_batch(fake_async_fcm_client_w_creds, fake_multi_device_token
     messages = [
         Message(apns=apns_config, token=fake_device_token) for fake_device_token in fake_multi_device_tokens
     ]
-    response = await fake_async_fcm_client_w_creds.push_batch(messages)
+    response = await fake_async_fcm_client_w_creds.send_all(messages)
     assert isinstance(response, FcmPushBatchResponse)
     assert response.success_count == 3
     assert response.failure_count == 0
@@ -370,7 +370,7 @@ async def test_push_batch_dry_run(
     messages = [
         Message(apns=apns_config, token=fake_device_token) for fake_device_token in fake_multi_device_tokens
     ]
-    response = await fake_async_fcm_client_w_creds.push_batch(messages, dry_run=True)
+    response = await fake_async_fcm_client_w_creds.send_all(messages, dry_run=True)
 
     assert isinstance(response, FcmPushBatchResponse)
     assert response.success_count == 3
@@ -395,7 +395,7 @@ async def test_push_multicast_too_many_tokens(
         custom_data={"foo": "bar"},
     )
     with pytest.raises(ValueError):
-        await fake_async_fcm_client_w_creds.push_multicast(
+        await fake_async_fcm_client_w_creds.send_multicast(
             MulticastMessage(apns=apns_config, tokens=fake_multi_device_tokens),
             dry_run=True
         )
@@ -426,7 +426,7 @@ async def test_push_batch_unknown_registration_token(fake_async_fcm_client_w_cre
         custom_data={"foo": "bar"},
     )
     messages = [Message(apns=apns_config, token="qwerty:ytrewq")]
-    response = await fake_async_fcm_client_w_creds.push_batch(messages)
+    response = await fake_async_fcm_client_w_creds.send_all(messages)
 
     assert isinstance(response, FcmPushBatchResponse)
     assert response.success_count == 0
@@ -466,7 +466,7 @@ async def test_push_response_error_invalid_argument(fake_async_fcm_client_w_cred
         custom_data={"foo": "bar"},
     )
     messages = [Message(apns=apns_config, token="qwerty:ytrewq")]
-    response = await fake_async_fcm_client_w_creds.push_batch(messages)
+    response = await fake_async_fcm_client_w_creds.send_all(messages)
 
     assert isinstance(response, FcmPushBatchResponse)
     assert response.success_count == 0
@@ -478,7 +478,7 @@ async def test_push_response_error_invalid_argument(fake_async_fcm_client_w_cred
 async def test_push_batch_data_has_not_provided(fake_async_fcm_client_w_creds):
     messages = [Message(token="device_id:device_token")]
     with pytest.raises(ValueError):
-        await fake_async_fcm_client_w_creds.push_batch(messages)
+        await fake_async_fcm_client_w_creds.send_all(messages)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,11 +15,11 @@ from async_firebase.messages import (
     APNSPayload,
     Aps,
     ApsAlert,
-    FcmPushMulticastResponse,
+    FcmPushBatchResponse,
     FcmPushResponse,
     Message,
     WebpushConfig,
-    WebpushNotification, WebpushFCMOptions,
+    WebpushNotification, WebpushFCMOptions, MulticastMessage,
 )
 from async_firebase.utils import FcmErrorCode
 
@@ -133,7 +133,7 @@ def test_build_apns_config(fake_async_fcm_client_w_creds, freezer):
     )
 
 
-async def test__prepare_headers(fake_async_fcm_client_w_creds):
+async def test_prepare_headers(fake_async_fcm_client_w_creds):
     fake_async_fcm_client_w_creds._get_access_token = fake__get_access_token
     frozen_uuid = uuid.UUID(hex="6eadf1d38633427cb83dbb9be137f48c")
     fake_async_fcm_client_w_creds.get_request_id = lambda: str(frozen_uuid)
@@ -162,7 +162,8 @@ async def test_push(fake_async_fcm_client_w_creds, fake_device_token, httpx_mock
         category="test-category",
         custom_data={"foo": "bar"},
     )
-    response = await fake_async_fcm_client_w_creds.push(device_token=fake_device_token, apns=apns_config)
+    message = Message(apns=apns_config, token=fake_device_token)
+    response = await fake_async_fcm_client_w_creds.push(message)
     assert isinstance(response, FcmPushResponse)
     assert response.success
     assert response.message_id == "projects/fake-mobile-app/messages/0:1612788010922733%7606eb247606eb24"
@@ -183,7 +184,8 @@ async def test_push_dry_run(fake_async_fcm_client_w_creds, fake_device_token, ht
         category="test-category",
         custom_data={"foo": "bar"},
     )
-    response = await fake_async_fcm_client_w_creds.push(device_token=fake_device_token, apns=apns_config, dry_run=True)
+    message = Message(apns=apns_config, token=fake_device_token)
+    response = await fake_async_fcm_client_w_creds.push(message, dry_run=True)
     assert isinstance(response, FcmPushResponse)
     assert response.success
     assert response.message_id == "projects/fake-mobile-app/messages/fake_message_id"
@@ -212,7 +214,8 @@ async def test_push_unauthenticated(fake_async_fcm_client_w_creds, httpx_mock: H
         category="test-category",
         custom_data={"foo": "bar"},
     )
-    fcm_response = await fake_async_fcm_client_w_creds.push(device_token="qwerty:ytrewq", apns=apns_config)
+    message = Message(apns=apns_config, token="qwerty:ytrewq")
+    fcm_response = await fake_async_fcm_client_w_creds.push(message)
 
     assert isinstance(fcm_response, FcmPushResponse)
     assert not fcm_response.success
@@ -222,8 +225,9 @@ async def test_push_unauthenticated(fake_async_fcm_client_w_creds, httpx_mock: H
 
 
 async def test_push_data_has_not_provided(fake_async_fcm_client_w_creds):
+    message = Message(token="device_id:device_token")
     with pytest.raises(ValueError):
-        await fake_async_fcm_client_w_creds.push(device_token="device_id:device_token")
+        await fake_async_fcm_client_w_creds.push(message)
 
 
 def test_creds_from_service_account_info(fake_async_fcm_client, fake_service_account):
@@ -258,7 +262,8 @@ async def test_push_realistic_payload(fake_async_fcm_client_w_creds, fake_device
         mutable_content=True,
         content_available=True,
     )
-    await fake_async_fcm_client_w_creds.push(device_token=fake_device_token, apns=apns_config)
+    message = Message(apns=apns_config, token=fake_device_token)
+    await fake_async_fcm_client_w_creds.push(message)
     request_payload = json.loads(httpx_mock.get_requests()[0].read())
     assert request_payload == {
         "message": {
@@ -284,7 +289,7 @@ async def test_push_realistic_payload(fake_async_fcm_client_w_creds, fake_device
 
 
 @pytest.mark.parametrize("fake_multi_device_tokens", (3,), indirect=True)
-async def test_push_multicast(fake_async_fcm_client_w_creds, fake_multi_device_tokens, httpx_mock: HTTPXMock):
+async def test_push_batch(fake_async_fcm_client_w_creds, fake_multi_device_tokens: list, httpx_mock: HTTPXMock):
     fake_async_fcm_client_w_creds._get_access_token = fake__get_access_token
     creds = fake_async_fcm_client_w_creds._credentials
     response_data = (
@@ -316,10 +321,11 @@ async def test_push_multicast(fake_async_fcm_client_w_creds, fake_multi_device_t
         category="test-category",
         custom_data={"foo": "bar"},
     )
-    response = await fake_async_fcm_client_w_creds.push_multicast(
-        device_tokens=fake_multi_device_tokens, apns=apns_config
-    )
-    assert isinstance(response, FcmPushMulticastResponse)
+    messages = [
+        Message(apns=apns_config, token=fake_device_token) for fake_device_token in fake_multi_device_tokens
+    ]
+    response = await fake_async_fcm_client_w_creds.push_batch(messages)
+    assert isinstance(response, FcmPushBatchResponse)
     assert response.success_count == 3
     assert response.failure_count == 0
     assert response.responses[0].message_id == "projects/fake-mobile-app/messages/0:1612788010922733%7606eb247606eb24"
@@ -328,7 +334,9 @@ async def test_push_multicast(fake_async_fcm_client_w_creds, fake_multi_device_t
 
 
 @pytest.mark.parametrize("fake_multi_device_tokens", (3,), indirect=True)
-async def test_push_multicast_dry_run(fake_async_fcm_client_w_creds, fake_multi_device_tokens, httpx_mock: HTTPXMock):
+async def test_push_batch_dry_run(
+    fake_async_fcm_client_w_creds, fake_multi_device_tokens: list, httpx_mock: HTTPXMock
+):
     fake_async_fcm_client_w_creds._get_access_token = fake__get_access_token
     creds = fake_async_fcm_client_w_creds._credentials
     response_data = (
@@ -359,11 +367,12 @@ async def test_push_multicast_dry_run(fake_async_fcm_client_w_creds, fake_multi_
         category="test-category",
         custom_data={"foo": "bar"},
     )
-    response = await fake_async_fcm_client_w_creds.push_multicast(
-        device_tokens=fake_multi_device_tokens, apns=apns_config, dry_run=True
-    )
+    messages = [
+        Message(apns=apns_config, token=fake_device_token) for fake_device_token in fake_multi_device_tokens
+    ]
+    response = await fake_async_fcm_client_w_creds.push_batch(messages, dry_run=True)
 
-    assert isinstance(response, FcmPushMulticastResponse)
+    assert isinstance(response, FcmPushBatchResponse)
     assert response.success_count == 3
     assert response.failure_count == 0
     assert response.responses[0].message_id == "projects/fake-mobile-app/messages/fake_message_id"
@@ -374,7 +383,7 @@ async def test_push_multicast_dry_run(fake_async_fcm_client_w_creds, fake_multi_
 @pytest.mark.parametrize("fake_multi_device_tokens", (501, 600, 1000), indirect=True)
 async def test_push_multicast_too_many_tokens(
     fake_async_fcm_client_w_creds,
-    fake_multi_device_tokens,
+    fake_multi_device_tokens: list,
 ):
     fake_async_fcm_client_w_creds._get_access_token = fake__get_access_token
     apns_config = fake_async_fcm_client_w_creds.build_apns_config(
@@ -387,11 +396,12 @@ async def test_push_multicast_too_many_tokens(
     )
     with pytest.raises(ValueError):
         await fake_async_fcm_client_w_creds.push_multicast(
-            device_tokens=fake_multi_device_tokens, apns=apns_config, dry_run=True
+            MulticastMessage(apns=apns_config, tokens=fake_multi_device_tokens),
+            dry_run=True
         )
 
 
-async def test_push_multicast_unknown_registration_token(fake_async_fcm_client_w_creds, httpx_mock: HTTPXMock):
+async def test_push_batch_unknown_registration_token(fake_async_fcm_client_w_creds, httpx_mock: HTTPXMock):
     fake_async_fcm_client_w_creds._get_access_token = fake__get_access_token
     response_data = (
         "\r\n--batch_HwFDZe-SUCq5qEgCavJPhhi8tA7xJBlB\r\nContent-Type: application/http\r\nContent-ID: "
@@ -415,9 +425,10 @@ async def test_push_multicast_unknown_registration_token(fake_async_fcm_client_w
         category="test-category",
         custom_data={"foo": "bar"},
     )
-    response = await fake_async_fcm_client_w_creds.push_multicast(device_tokens=["qwerty:ytrewq"], apns=apns_config)
+    messages = [Message(apns=apns_config, token="qwerty:ytrewq")]
+    response = await fake_async_fcm_client_w_creds.push_batch(messages)
 
-    assert isinstance(response, FcmPushMulticastResponse)
+    assert isinstance(response, FcmPushBatchResponse)
     assert response.success_count == 0
     assert response.failure_count == 1
     assert response.responses[0].exception.code == FcmErrorCode.INVALID_ARGUMENT.value
@@ -454,18 +465,20 @@ async def test_push_response_error_invalid_argument(fake_async_fcm_client_w_cred
         category="test-category",
         custom_data={"foo": "bar"},
     )
-    response = await fake_async_fcm_client_w_creds.push_multicast(device_tokens=["qwerty:ytrewq"], apns=apns_config)
+    messages = [Message(apns=apns_config, token="qwerty:ytrewq")]
+    response = await fake_async_fcm_client_w_creds.push_batch(messages)
 
-    assert isinstance(response, FcmPushMulticastResponse)
+    assert isinstance(response, FcmPushBatchResponse)
     assert response.success_count == 0
     assert response.failure_count == 1
     assert response.responses[0].exception.code == FcmErrorCode.INVALID_ARGUMENT.value
     assert response.responses[0].exception.cause.response.status_code == 400
 
 
-async def test_push_multicast_data_has_not_provided(fake_async_fcm_client_w_creds):
+async def test_push_batch_data_has_not_provided(fake_async_fcm_client_w_creds):
+    messages = [Message(token="device_id:device_token")]
     with pytest.raises(ValueError):
-        await fake_async_fcm_client_w_creds.push_multicast(device_tokens=["device_id:device_token"])
+        await fake_async_fcm_client_w_creds.push_batch(messages)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Introduce the method ``AsyncFirebaseClient.push_batch`` to send multiple messages in a single batch.