### PR TITLE
fix: Push notification can't be sent to topic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1
+* [FIX] The push notification could not be sent to topic because ``messages.Message.token`` is declared as required attribute though it should be optional.
+``messages.Message.token`` turned into Optional attribute.
+
 ## 3.1.0
 * The limit on the number of messages (>= 500) that can be sent using the ``send_all`` method has been restored.
 

--- a/async_firebase/messages.py
+++ b/async_firebase/messages.py
@@ -299,7 +299,7 @@ class Message:
     condition: the Firebase condition to which the message should be sent (optional).
     """
 
-    token: str
+    token: t.Optional[str] = None
     data: t.Dict[str, str] = field(default_factory=dict)
     notification: t.Optional[Notification] = field(default=None)
     android: t.Optional[AndroidConfig] = field(default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-firebase"
-version = "3.1.0"
+version = "3.1.1"
 description = "Async Firebase Client - a Python asyncio client to interact with Firebase Cloud Messaging in an easy way."
 license = "MIT"
 authors = [


### PR DESCRIPTION
That happens because the attribute ``token`` is marked as required. The PR is about to change that.