### PR TITLE
Add fcm options attr to multicast message

### DIFF
--- a/async_firebase/client.py
+++ b/async_firebase/client.py
@@ -435,6 +435,7 @@ class AsyncFirebaseClient(AsyncClientBase):
                 android=multicast_message.android,
                 webpush=multicast_message.webpush,
                 apns=multicast_message.apns,
+                fcm_options=multicast_message.fcm_options,
             )
             for token in multicast_message.tokens
         ]
@@ -544,6 +545,7 @@ class AsyncFirebaseClient(AsyncClientBase):
                 android=multicast_message.android,
                 webpush=multicast_message.webpush,
                 apns=multicast_message.apns,
+                fcm_options=multicast_message.fcm_options,
             )
             for token in multicast_message.tokens
         ]

--- a/async_firebase/messages.py
+++ b/async_firebase/messages.py
@@ -321,7 +321,7 @@ class Message:
     apns: t.Optional[APNSConfig] = field(default=None)
     topic: t.Optional[str] = None
     condition: t.Optional[str] = None
-    fcm_options: t.Optional[FcmOptions] = None
+    fcm_options: t.Optional[FcmOptions] = field(default=None)
 
 
 @dataclass
@@ -345,7 +345,7 @@ class MulticastMessage:
     android: t.Optional[AndroidConfig] = field(default=None)
     webpush: t.Optional[WebpushConfig] = field(default=None)
     apns: t.Optional[APNSConfig] = field(default=None)
-    fcm_options: t.Optional[FcmOptions] = None
+    fcm_options: t.Optional[FcmOptions] = field(default=None)
 
 
 @dataclass

--- a/async_firebase/messages.py
+++ b/async_firebase/messages.py
@@ -336,6 +336,7 @@ class MulticastMessage:
     android: an instance of ``messages.AndroidConfig`` (optional).
     webpush: an instance of ``messages.WebpushConfig`` (optional).
     apns: an instance of ``messages.ApnsConfig`` (optional).
+    fcm_options: platform independent options for features provided by the FCM SDKs.
     """
 
     tokens: t.List[str]
@@ -344,6 +345,7 @@ class MulticastMessage:
     android: t.Optional[AndroidConfig] = field(default=None)
     webpush: t.Optional[WebpushConfig] = field(default=None)
     apns: t.Optional[APNSConfig] = field(default=None)
+    fcm_options: t.Optional[FcmOptions] = None
 
 
 @dataclass


### PR DESCRIPTION
1. Add fcm_options attribute to MulticastMessage dataclass.
2. Update Message instances generation with  fcm_options at multicast methods.