### PR TITLE
fix(deps): Bump pyasn1 to 0.6.4 to address three DoS advisories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.2.1
+* Resolve security concerns by updating the transitive `pyasn1` dependency (pulled in via `google-auth`) to `0.6.4`. No API changes.
+  * [High] pyasn1 BER/CER/DER decoder denial of service via unbounded long-form tag IDs ([GHSA-m4p7-r5rc-7g4j](https://github.com/advisories/GHSA-m4p7-r5rc-7g4j))
+  * [High] Quadratic complexity in OBJECT IDENTIFIER and RELATIVE-OID processing allows denial of service ([GHSA-8ppf-4f7h-5ppj](https://github.com/advisories/GHSA-8ppf-4f7h-5ppj))
+  * [High] Uncontrolled resource consumption when converting decoded REAL values ([GHSA-hm4w-wwcw-mr6r](https://github.com/advisories/GHSA-hm4w-wwcw-mr6r))
+
 ## 6.2.0
 * Add support for the Firebase installation ID (``fid``), the successor to the registration ``token``.
   * ``Message`` gains a ``fid`` field. A message must target exactly one of ``fid``, ``token``, ``topic`` or ``condition`` — this is now validated during serialization.

--- a/poetry.lock
+++ b/poetry.lock
@@ -767,14 +767,14 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "async-firebase"
-version = "6.2.0"
+version = "6.2.1"
 description = "Async Firebase Client - a Python asyncio client to interact with Firebase Cloud Messaging in an easy way."
 license = "MIT"
 authors = [


### PR DESCRIPTION
Resolves Dependabot alerts #36, #37, #38 (all high severity), fixed in pyasn1 0.6.4:

- GHSA-m4p7-r5rc-7g4j: BER/CER/DER decoder DoS via unbounded long-form tag IDs
- GHSA-8ppf-4f7h-5ppj: quadratic complexity in OBJECT IDENTIFIER and RELATIVE-OID processing
- GHSA-hm4w-wwcw-mr6r: uncontrolled resource consumption when converting decoded REAL values

pyasn1 is a transitive dependency via google-auth, so only poetry.lock changes. Release 6.2.1.