### PR TITLE
ci: Run the release job in the release environment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    environment: release
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Problem

The PyPI trusted publisher for `async-firebase` is configured with **Environment: `release`**, but `cd.yml` declares no environment. OIDC claims must match exactly, so `uv publish` would be rejected on the next tagged release.

Two things were wrong, not one:

1. `cd.yml` did not declare `environment: release`.
2. **No `release` environment existed on the repo** — `GET /repos/healthjoy/async-firebase/environments` returned `total_count: 0`.

Note this predates the Poetry→uv migration. The environment mismatch would have broken a tagged release under the old token-based flow too; it just went unnoticed because no release has been cut since the publisher was configured.

## Fix

- Added `environment: release` to the `release` job.
- Created the `release` environment on the repo (previously missing).

## Effect

Aligns the workflow with the existing PyPI publisher, so no PyPI-side change is needed. The environment is also now available to carry protection rules (required reviewers, tag restrictions) if you want to gate publishes later.

## Verification

- ✅ YAML parses; job resolves to `environment: release` with `permissions: {contents: read, id-token: write}`
- ✅ `release` environment now exists on the repo
- ⚠️ End-to-end OIDC publishing still only proves out on a real tagged release