### PR TITLE
chore(release): 6.2.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## 6.2.2
+No runtime or API changes — this release contains internal tooling changes only, and the
+installed library code is identical to 6.2.1.
+
+* Bump the `cryptography` development dependency to `>=50.0.0` ([GHSA-g6cj-pr64-35w5](https://github.com/advisories/GHSA-g6cj-pr64-35w5)).
+  `cryptography` is used only by the test suite; it is not a runtime dependency of this package,
+  so installed environments are unaffected.
 * Migrate the project's tooling from Poetry to [uv](https://docs.astral.sh/uv/). This changes
   development workflow only — the published package, its runtime dependencies, and the
   `hatchling` build backend are unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "async-firebase"
-version = "6.2.1"
+version = "6.2.2"
 description = "Async Firebase Client - a Python asyncio client to interact with Firebase Cloud Messaging in an easy way."
 license = "MIT"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "async-firebase"
-version = "6.2.1"
+version = "6.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-auth" },


### PR DESCRIPTION
## Summary

Cuts **6.2.2**, a tooling-only patch release. The installed library code is byte-identical to 6.2.1 — no runtime changes, no API changes, no dependency changes for consumers.

## Why release at all?

Two changes have accumulated on master since `v6.2.1` and neither has shipped:

- `ca83847` — the Poetry→uv migration
- `59fc51f` — `cryptography` dev-dependency bump for [GHSA-g6cj-pr64-35w5](https://github.com/advisories/GHSA-g6cj-pr64-35w5)

Both are internal. The changelog says so plainly rather than dressing them up as user-facing.

This release also serves as the first real exercise of the new OIDC publishing path, which cannot be verified any other way.

## Note on the cryptography bump

`cryptography` is a **dev** dependency used only by the test suite — it is not in `[project.dependencies]`. Installed environments were never exposed to the advisory. The changelog entry states this explicitly so nobody reads 6.2.2 as a security release for consumers.

## Changes

- `pyproject.toml`: `version = "6.2.1"` → `"6.2.2"`
- `uv.lock`: regenerated (version field only)
- `CHANGES.md`: `## Unreleased` → `## 6.2.2`, plus an entry for the previously undocumented cryptography bump

## Verification

- ✅ `uv sync --locked` — lock consistent with pyproject
- ✅ `138 passed, 8 skipped` — unchanged from baseline
- ✅ `uv build` produces `async_firebase-6.2.2` sdist + wheel
- ✅ `twine check` PASSED on both artifacts

## After merge

Tag `v6.2.2` on master to trigger the release. The `release` environment is gated to `v*` tags, and the PyPI trusted publisher is configured to match.

⚠️ There is no `PYPI_TOKEN` fallback — OIDC is the only publish path. If it fails, recovery is a local `uv build && uv publish --token ...`.